### PR TITLE
Benchmark unit methods

### DIFF
--- a/.github/workflows/bench_pr.yaml
+++ b/.github/workflows/bench_pr.yaml
@@ -1,0 +1,22 @@
+name: Bench PR
+
+on: [workflow_dispatch]
+
+jobs:
+  bench:
+    name: Bench
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - name: Run Criterion
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          args: --workspace

--- a/tb-suite/Cargo.toml
+++ b/tb-suite/Cargo.toml
@@ -11,4 +11,5 @@ block-grid = { path = ".." }
 array2d = "0.2.1"
 
 [dev-dependencies]
+criterion = "0.3.3"
 fastrand = "1.3.3"

--- a/tb-suite/Cargo.toml
+++ b/tb-suite/Cargo.toml
@@ -13,3 +13,7 @@ array2d = "0.2.1"
 [dev-dependencies]
 criterion = "0.3.3"
 fastrand = "1.3.3"
+
+[[bench]]
+name = "unit"
+harness = false

--- a/tb-suite/benches/unit.rs
+++ b/tb-suite/benches/unit.rs
@@ -1,0 +1,11 @@
+extern crate block_grid;
+extern crate criterion;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+// TODO: Add tests
+
+fn empty(_c: &mut Criterion) {}
+
+criterion_group!(bench, empty);
+criterion_main!(bench);

--- a/tb-suite/benches/unit.rs
+++ b/tb-suite/benches/unit.rs
@@ -1,11 +1,37 @@
 extern crate block_grid;
 extern crate criterion;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use block_grid::{BlockWidth::*, *};
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 
-// TODO: Add tests
+fn constructors(c: &mut Criterion) {
+    const DIMS: Coords = (128, 256);
 
-fn empty(_c: &mut Criterion) {}
+    fn gen_data_u8(len: usize) -> Vec<u8> {
+        (0..len).map(|x| x as u8).collect()
+    }
 
-criterion_group!(bench, empty);
+    fn bench_from_row_major<B: BlockDim>() -> impl Fn(&mut Bencher, &Coords) {
+        |b, &(rows, cols)| {
+            assert!(rows % B::WIDTH == 0 && cols % B::WIDTH == 0);
+            let data = gen_data_u8(rows * cols);
+            b.iter_with_large_drop(|| BlockGrid::<_, B>::from_row_major(rows, cols, &data))
+        }
+    }
+    let mut g = c.benchmark_group("Constructors");
+    g.bench_with_input("from_row_major<U2>", &DIMS, bench_from_row_major::<U2>());
+    g.bench_with_input("from_row_major<U8>", &DIMS, bench_from_row_major::<U8>());
+
+    fn bench_from_col_major<B: BlockDim>() -> impl Fn(&mut Bencher, &Coords) {
+        |b, &(rows, cols)| {
+            let data = gen_data_u8(rows * cols);
+            b.iter_with_large_drop(|| BlockGrid::<_, B>::from_col_major(rows, cols, &data))
+        }
+    }
+    g.bench_with_input("from_col_major<U2>", &DIMS, bench_from_col_major::<U2>());
+    g.bench_with_input("from_col_major<U8>", &DIMS, bench_from_col_major::<U8>());
+    g.finish();
+}
+
+criterion_group!(bench, constructors);
 criterion_main!(bench);

--- a/tb-suite/benches/unit.rs
+++ b/tb-suite/benches/unit.rs
@@ -81,5 +81,53 @@ fn indexing(c: &mut Criterion) {
     });
 }
 
-criterion_group!(bench, constructors, indexing);
+fn iterators(c: &mut Criterion) {
+    type B = U4;
+    const DIMS: Coords = (128, 64);
+    let data: Vec<_> = (0..(DIMS.0 * DIMS.1)).map(|x| x as u32).collect();
+    let grid = BlockGrid::<_, B>::from_raw_vec(DIMS.0, DIMS.1, data).unwrap();
+
+    let mut g = c.benchmark_group("Iterators");
+    g.bench_function("each_iter", |b| {
+        b.iter(|| {
+            for x in grid.each_iter() {
+                black_box(x);
+            }
+        })
+    });
+
+    g.bench_function("block_iter_index", |b| {
+        b.iter(|| {
+            for block in grid.block_iter() {
+                for i in 0..B::WIDTH {
+                    for j in 0..B::WIDTH {
+                        black_box(block[(i, j)]);
+                    }
+                }
+            }
+        })
+    });
+
+    g.bench_function("block_iter_get_unchecked", |b| {
+        b.iter(|| {
+            for block in grid.block_iter() {
+                for i in 0..B::WIDTH {
+                    for j in 0..B::WIDTH {
+                        black_box(unsafe { block.get_unchecked((i, j)) });
+                    }
+                }
+            }
+        })
+    });
+
+    g.bench_function("row_major_iter", |b| {
+        b.iter(|| {
+            for (c, x) in grid.row_major_iter() {
+                black_box((c, x));
+            }
+        })
+    });
+}
+
+criterion_group!(bench, constructors, indexing, iterators);
 criterion_main!(bench);


### PR DESCRIPTION
Using Criterion.rs, create benches for some functions (just like `src/tests.rs`).
Things to bench:

- [x] `from_raw_major` and `from_col_major`
- [x] `Index` and `get_unchecked`, in row-major and memory order
- [x] `each_iter`, `row_major_iter`, and `block_iter`

Closes #7.