### PR TITLE
Indexing blur test bench against toodee

### DIFF
--- a/tb-suite/Cargo.toml
+++ b/tb-suite/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 block-grid = { path = ".." }
 array2d = "0.2.1"
+toodee = "0.2.1"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/tb-suite/benches/blur.rs
+++ b/tb-suite/benches/blur.rs
@@ -3,11 +3,13 @@ extern crate block_grid;
 extern crate criterion;
 extern crate fastrand;
 extern crate tb_suite;
+extern crate toodee;
 
 use array2d::Array2D;
 use block_grid::{BlockGrid, BlockWidth};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use tb_suite::blur::*;
+use toodee::TooDee;
 
 type B = BlockWidth::U8;
 
@@ -21,6 +23,9 @@ fn bench_blur(c: &mut Criterion) {
     let mut in_ar = Array2D::filled_with(0u8, ROWS, COLS);
     let out_ar = in_ar.clone();
 
+    let mut in_td = TooDee::<u8>::new(ROWS, COLS);
+    let out_td = in_td.clone();
+
     // Generate input data
     fastrand::seed(1234);
     for i in 0..ROWS {
@@ -28,6 +33,7 @@ fn bench_blur(c: &mut Criterion) {
             let x = fastrand::u8(..);
             in_bg[(i, j)] = x;
             in_ar[(i, j)] = x;
+            in_td[(i, j)] = x;
         }
     }
 
@@ -47,6 +53,16 @@ fn bench_blur(c: &mut Criterion) {
             || out_ar.clone(),
             |out_grid| {
                 blur_by_index(ROWS, COLS, &in_ar, out_grid);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    g.bench_function("toodee_index", |b| {
+        b.iter_batched_ref(
+            || out_td.clone(),
+            |out_grid| {
+                blur_by_index(ROWS, COLS, &in_td, out_grid);
             },
             BatchSize::SmallInput,
         );

--- a/tb-suite/tests/blur.rs
+++ b/tb-suite/tests/blur.rs
@@ -2,10 +2,12 @@ extern crate array2d;
 extern crate block_grid;
 extern crate fastrand;
 extern crate tb_suite;
+extern crate toodee;
 
 use array2d::Array2D;
 use block_grid::{BlockDim, BlockGrid, BlockWidth::*};
 use tb_suite::blur::*;
+use toodee::TooDee;
 
 fn generic_test_blur<B: BlockDim>(rows: usize, cols: usize) {
     let mut in_bg = BlockGrid::<u8, B>::new(rows, cols).unwrap();
@@ -14,21 +16,28 @@ fn generic_test_blur<B: BlockDim>(rows: usize, cols: usize) {
     let mut in_ar = Array2D::filled_with(0u8, rows, cols);
     let mut out_ar = in_ar.clone();
 
+    let mut in_td = TooDee::<u8>::new(rows, cols);
+    let mut out_td = in_td.clone();
+
     fastrand::seed(1234);
     for i in 0..rows {
         for j in 0..cols {
             let x = fastrand::u8(..);
             in_bg[(i, j)] = x;
             in_ar[(i, j)] = x;
+            in_td[(i, j)] = x;
         }
     }
 
     blur_by_index(rows, cols, &in_bg, &mut out_bg);
     blur_by_index(rows, cols, &in_ar, &mut out_ar);
+    blur_by_index(rows, cols, &in_td, &mut out_td);
 
     for i in 0..rows {
         for j in 0..cols {
-            assert_eq!(out_bg[(i, j)], out_ar[(i, j)]);
+            let x = out_bg[(i, j)];
+            assert_eq!(out_ar[(i, j)], x);
+            assert_eq!(out_td[(i, j)], x);
         }
     }
 }


### PR DESCRIPTION
Test and bench naive indexing box blur against the `toodee` crate.