### PR TITLE
Revert "Indexing blur test bench against toodee"

### DIFF
--- a/tb-suite/Cargo.toml
+++ b/tb-suite/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 [dependencies]
 block-grid = { path = ".." }
 array2d = "0.2.1"
-toodee = "0.2.1"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/tb-suite/benches/blur.rs
+++ b/tb-suite/benches/blur.rs
@@ -3,13 +3,11 @@ extern crate block_grid;
 extern crate criterion;
 extern crate fastrand;
 extern crate tb_suite;
-extern crate toodee;
 
 use array2d::Array2D;
 use block_grid::{BlockGrid, BlockWidth};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use tb_suite::blur::*;
-use toodee::TooDee;
 
 type B = BlockWidth::U8;
 
@@ -23,9 +21,6 @@ fn bench_blur(c: &mut Criterion) {
     let mut in_ar = Array2D::filled_with(0u8, ROWS, COLS);
     let out_ar = in_ar.clone();
 
-    let mut in_td = TooDee::<u8>::new(ROWS, COLS);
-    let out_td = in_td.clone();
-
     // Generate input data
     fastrand::seed(1234);
     for i in 0..ROWS {
@@ -33,7 +28,6 @@ fn bench_blur(c: &mut Criterion) {
             let x = fastrand::u8(..);
             in_bg[(i, j)] = x;
             in_ar[(i, j)] = x;
-            in_td[(i, j)] = x;
         }
     }
 
@@ -53,16 +47,6 @@ fn bench_blur(c: &mut Criterion) {
             || out_ar.clone(),
             |out_grid| {
                 blur_by_index(ROWS, COLS, &in_ar, out_grid);
-            },
-            BatchSize::SmallInput,
-        );
-    });
-
-    g.bench_function("toodee_index", |b| {
-        b.iter_batched_ref(
-            || out_td.clone(),
-            |out_grid| {
-                blur_by_index(ROWS, COLS, &in_td, out_grid);
             },
             BatchSize::SmallInput,
         );

--- a/tb-suite/tests/blur.rs
+++ b/tb-suite/tests/blur.rs
@@ -2,12 +2,10 @@ extern crate array2d;
 extern crate block_grid;
 extern crate fastrand;
 extern crate tb_suite;
-extern crate toodee;
 
 use array2d::Array2D;
 use block_grid::{BlockDim, BlockGrid, BlockWidth::*};
 use tb_suite::blur::*;
-use toodee::TooDee;
 
 fn generic_test_blur<B: BlockDim>(rows: usize, cols: usize) {
     let mut in_bg = BlockGrid::<u8, B>::new(rows, cols).unwrap();
@@ -16,28 +14,21 @@ fn generic_test_blur<B: BlockDim>(rows: usize, cols: usize) {
     let mut in_ar = Array2D::filled_with(0u8, rows, cols);
     let mut out_ar = in_ar.clone();
 
-    let mut in_td = TooDee::<u8>::new(rows, cols);
-    let mut out_td = in_td.clone();
-
     fastrand::seed(1234);
     for i in 0..rows {
         for j in 0..cols {
             let x = fastrand::u8(..);
             in_bg[(i, j)] = x;
             in_ar[(i, j)] = x;
-            in_td[(i, j)] = x;
         }
     }
 
     blur_by_index(rows, cols, &in_bg, &mut out_bg);
     blur_by_index(rows, cols, &in_ar, &mut out_ar);
-    blur_by_index(rows, cols, &in_td, &mut out_td);
 
     for i in 0..rows {
         for j in 0..cols {
-            let x = out_bg[(i, j)];
-            assert_eq!(out_ar[(i, j)], x);
-            assert_eq!(out_td[(i, j)], x);
+            assert_eq!(out_bg[(i, j)], out_ar[(i, j)]);
         }
     }
 }


### PR DESCRIPTION
Reverts gunvirranu/block-grid#16. This removes all `toodee` related code from the test-bench suite.

Multiple reasons:
- `toodee` uses `(col, row)` indexing, so `blur_by_index` is probably just _slightly_ slower than it could be
- `toodee` supports resizing, which isn't a use-case of this lib, so it's not exactly a good comparison
- The idiomatic blur using `toodee` doesn't seem too different from indexing, nor is it actually "nice" code

So there isn't much use to comparing with `toodee`. Considering comparing with `imgref`, but that's for later.