### PR TITLE
Add coordinates to each iter

### DIFF
--- a/src/block_grid.rs
+++ b/src/block_grid.rs
@@ -102,8 +102,13 @@ impl<T, B: BlockDim> BlockGrid<T, B> {
         self.buf.get_unchecked_mut(ind)
     }
 
-    pub fn each_iter(&self) -> impl Iterator<Item = &T> + ExactSizeIterator {
-        self.buf.iter()
+    pub fn each_iter(&self) -> impl Iterator<Item = (Coords, &T)> + ExactSizeIterator {
+        let col_blocks = self.col_blocks();
+        self.buf
+            .iter()
+            .enumerate()
+            // TODO: Bench against `EachIterCoords` adapter that holds state
+            .map(move |(ind, x)| (Self::mem_index_to_coords(ind, col_blocks), x))
     }
 
     pub fn each_iter_mut(&mut self) -> impl Iterator<Item = &mut T> + ExactSizeIterator {
@@ -168,6 +173,15 @@ impl<T, B: BlockDim> BlockGrid<T, B> {
 
     fn calc_offset(&self, (row, col): Coords) -> Coords {
         (row & B::MASK, col & B::MASK)
+    }
+
+    // Have to take `col_blocks` so `self` isn't aliased
+    fn mem_index_to_coords(ind: usize, col_blocks: usize) -> Coords {
+        let block = ind / B::AREA;
+        let intra_block = ind % B::AREA;
+        let row = B::WIDTH * (block / col_blocks) + (intra_block / B::WIDTH);
+        let col = B::WIDTH * (block % col_blocks) + (intra_block % B::WIDTH);
+        (row, col)
     }
 }
 

--- a/src/block_grid.rs
+++ b/src/block_grid.rs
@@ -111,8 +111,12 @@ impl<T, B: BlockDim> BlockGrid<T, B> {
             .map(move |(ind, x)| (Self::mem_index_to_coords(ind, col_blocks), x))
     }
 
-    pub fn each_iter_mut(&mut self) -> impl Iterator<Item = &mut T> + ExactSizeIterator {
-        self.buf.iter_mut()
+    pub fn each_iter_mut(&mut self) -> impl Iterator<Item = (Coords, &mut T)> + ExactSizeIterator {
+        let col_blocks = self.col_blocks();
+        self.buf
+            .iter_mut()
+            .enumerate()
+            .map(move |(ind, x)| (Self::mem_index_to_coords(ind, col_blocks), x))
     }
 
     pub fn block_iter(&self) -> BlockIter<T, B> {

--- a/tb-suite/benches/unit.rs
+++ b/tb-suite/benches/unit.rs
@@ -88,10 +88,18 @@ fn iterators(c: &mut Criterion) {
     let grid = BlockGrid::<_, B>::from_raw_vec(ROWS, COLS, data).unwrap();
 
     let mut g = c.benchmark_group("Iterators");
+    g.bench_function("each_iter_no_coords", |b| {
+        b.iter(|| {
+            for (_, x) in grid.each_iter() {
+                black_box(x);
+            }
+        })
+    });
+
     g.bench_function("each_iter", |b| {
         b.iter(|| {
-            for x in grid.each_iter() {
-                black_box(x);
+            for (c, x) in grid.each_iter() {
+                black_box((c, x));
             }
         })
     });


### PR DESCRIPTION
Should probably also implement a `EachIterCoords` adapter that holds state and generates the coordinates during iteration instead of on the fly (like this does), and then compare performance. See #25.

Closes #4.