### PR TITLE
Create optional coordinates iterator

### DIFF
--- a/src/iters.rs
+++ b/src/iters.rs
@@ -1,3 +1,4 @@
+use core::iter::FusedIterator;
 use core::marker::PhantomData;
 use core::ptr::NonNull;
 use core::slice::{ChunksExact, ChunksExactMut};
@@ -198,4 +199,10 @@ impl<I: CoordsIterator> Iterator for WithCoordsIter<I> {
     }
 }
 
-// TODO: Impl more iterator trait bounds
+impl<I: CoordsIterator + ExactSizeIterator> ExactSizeIterator for WithCoordsIter<I> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+impl<I: CoordsIterator + FusedIterator> FusedIterator for WithCoordsIter<I> {}

--- a/src/iters.rs
+++ b/src/iters.rs
@@ -84,8 +84,14 @@ impl<'a, T, B: BlockDim> RowMajorIter<'a, T, B> {
     }
 }
 
+impl<'a, T, B: BlockDim> CoordsIterator for RowMajorIter<'a, T, B> {
+    fn current_coords(&self) -> Coords {
+        self.coords
+    }
+}
+
 impl<'a, T, B: BlockDim> Iterator for RowMajorIter<'a, T, B> {
-    type Item = (Coords, &'a T);
+    type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {
         let c = self.coords;
@@ -93,8 +99,7 @@ impl<'a, T, B: BlockDim> Iterator for RowMajorIter<'a, T, B> {
         if self.coords.1 >= self.grid.cols() {
             self.coords = (c.0 + 1, 0);
         }
-        let elem = self.grid.get(c)?;
-        Some((c, elem))
+        self.grid.get(c)
     }
 }
 

--- a/src/iters.rs
+++ b/src/iters.rs
@@ -1,8 +1,8 @@
 use core::marker::PhantomData;
 use core::ptr::NonNull;
+use core::slice::{ChunksExact, ChunksExactMut};
 
 use crate::{Block, BlockDim, BlockGrid, BlockMut, Coords};
-use core::slice::{ChunksExact, ChunksExactMut};
 
 pub trait CoordsIterator: Iterator {
     fn current_coords(&self) -> Coords;
@@ -180,6 +180,21 @@ impl<I: CoordsIterator> Iterator for WithCoordsIter<I> {
     fn next(&mut self) -> Option<Self::Item> {
         let c = self.iter.current_coords();
         self.iter.next().map(|x| (c, x))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.iter.count()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if n > 1 {
+            self.iter.nth(n - 1)?;
+        }
+        self.next()
     }
 }
 

--- a/src/iters.rs
+++ b/src/iters.rs
@@ -113,8 +113,14 @@ impl<'a, T, B: BlockDim> RowMajorIterMut<'a, T, B> {
     }
 }
 
+impl<'a, T, B: BlockDim> CoordsIterator for RowMajorIterMut<'a, T, B> {
+    fn current_coords(&self) -> Coords {
+        self.coords
+    }
+}
+
 impl<'a, T, B: BlockDim> Iterator for RowMajorIterMut<'a, T, B> {
-    type Item = (Coords, &'a mut T);
+    type Item = &'a mut T;
 
     fn next(&mut self) -> Option<Self::Item> {
         let c = self.coords;
@@ -124,8 +130,7 @@ impl<'a, T, B: BlockDim> Iterator for RowMajorIterMut<'a, T, B> {
             self.coords = (c.0 + 1, 0);
         }
         // SAFETY: `self.grid` is a valid mutable pointer
-        let elem = unsafe { &mut *self.grid.as_ptr() }.get_mut(c)?;
-        Some((c, elem))
+        unsafe { &mut *self.grid.as_ptr() }.get_mut(c)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,5 +15,6 @@ mod tests;
 
 pub use crate::block_grid::{Block, BlockGrid, BlockMut};
 pub use crate::block_width::{BlockDim, BlockWidth};
+pub use crate::iters::CoordsIterator;
 
 pub type Coords = (usize, usize);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -174,19 +174,23 @@ fn gen_block_iter<B: BlockDim>() {
     assert_eq!(grid.block_iter().count(), grid.blocks());
 
     let (mut bi, mut bj): Coords = (0, 0);
-    for block in grid.block_iter() {
+    for (c, block) in grid.block_iter().coords() {
+        assert_eq!(c, (bi, bj));
         for si in 0..B::WIDTH {
             for sj in 0..B::WIDTH {
-                assert_eq!(block[(si, sj)], grid[(bi + si, bj + sj)]);
+                assert_eq!(
+                    block[(si, sj)],
+                    grid[(B::WIDTH * bi + si, B::WIDTH * bj + sj)]
+                );
             }
         }
         assert!(block.get((B::WIDTH, B::WIDTH - 1)).is_none());
         assert!(block.get((B::WIDTH - 1, B::WIDTH)).is_none());
         assert!(block.get((B::WIDTH, B::WIDTH)).is_none());
 
-        bj += B::WIDTH;
-        if bj == cols {
-            bi += B::WIDTH;
+        bj += 1;
+        if bj == grid.col_blocks() {
+            bi += 1;
             bj = 0;
         }
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -231,7 +231,7 @@ fn gen_row_major_iter<B: BlockDim>() {
     let grid = BG::<_, B>::from_raw_vec(rows, cols, data).unwrap();
     assert_eq!(grid.row_major_iter().count(), grid.size());
 
-    let mut it = grid.row_major_iter();
+    let mut it = grid.row_major_iter().coords();
     for i in 0..rows {
         for j in 0..cols {
             let (c, &e) = it.next().unwrap();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -247,7 +247,7 @@ fn gen_row_major_iter_mut<B: BlockDim>() {
     let mut grid = BG::<_, B>::filled(rows, cols, 7usize).unwrap();
     assert_eq!(grid.row_major_iter_mut().count(), grid.size());
     // Mutate while iterating
-    let mut it = grid.row_major_iter_mut();
+    let mut it = grid.row_major_iter_mut().coords();
     for i in 0..rows {
         for j in 0..cols {
             let (c, e) = it.next().unwrap();

--- a/tb-suite/benches/unit.rs
+++ b/tb-suite/benches/unit.rs
@@ -138,7 +138,7 @@ fn iterators(c: &mut Criterion) {
 
     g.bench_function("row_major_iter", |b| {
         b.iter(|| {
-            for (c, x) in grid.row_major_iter() {
+            for (c, x) in grid.row_major_iter().coords() {
                 black_box((c, x));
             }
         })

--- a/tb-suite/benches/unit.rs
+++ b/tb-suite/benches/unit.rs
@@ -112,6 +112,14 @@ fn iterators(c: &mut Criterion) {
         })
     });
 
+    g.bench_function("block_iter_coords", |b| {
+        b.iter(|| {
+            for (c, block) in grid.block_iter().coords() {
+                black_box((c, block));
+            }
+        })
+    });
+
     g.bench_function("block_iter_index", |b| {
         b.iter(|| {
             for block in grid.block_iter() {


### PR DESCRIPTION
Create `CoordsIterator` trait, which represents an iterator over the 2D grid in _some_ order with coordinates. Now each usual iterator doesn't provide coords by default, but can yield them using the `.coords()` adapter method.