### PR TITLE
Refactor each iter to custom type

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ fn main() {
     assert_eq!(block[(0, 1)], 17);
 
     // Iterate in row-major order
-    for (i, (_coords, &x)) in grid.row_major_iter().enumerate() {
+    for (i, &x) in grid.row_major_iter().enumerate() {
         assert_eq!(x, i);
     }
 
     // Iterate in memory order, with coordinates
-    for ((row, col), &x) in grid.each_iter() {
+    for ((row, col), &x) in grid.each_iter().coords() {
         assert_eq!(row * 6 + col, x);
     }
 }

--- a/src/block_grid.rs
+++ b/src/block_grid.rs
@@ -2,7 +2,7 @@ use alloc::{vec, vec::Vec};
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 
-use crate::iters::{BlockIter, BlockIterMut, RowMajorIter, RowMajorIterMut};
+use crate::iters::{BlockIter, BlockIterMut, EachIter, RowMajorIter, RowMajorIterMut};
 use crate::{BlockDim, Coords};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -125,13 +125,8 @@ impl<T, B: BlockDim> BlockGrid<T, B> {
     }
 
     #[inline]
-    pub fn each_iter(&self) -> impl Iterator<Item = (Coords, &T)> + ExactSizeIterator {
-        let col_blocks = self.col_blocks();
-        self.buf
-            .iter()
-            .enumerate()
-            // TODO: Bench against `EachIterCoords` adapter that holds state
-            .map(move |(ind, x)| (Self::mem_index_to_coords(ind, col_blocks), x))
+    pub fn each_iter(&self) -> EachIter<T, B> {
+        EachIter::new(self)
     }
 
     #[inline]

--- a/src/block_grid.rs
+++ b/src/block_grid.rs
@@ -2,7 +2,7 @@ use alloc::{vec, vec::Vec};
 use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 
-use crate::iters::{BlockIter, BlockIterMut, EachIter, RowMajorIter, RowMajorIterMut};
+use crate::iters::{BlockIter, BlockIterMut, EachIter, EachIterMut, RowMajorIter, RowMajorIterMut};
 use crate::{BlockDim, Coords};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -130,12 +130,8 @@ impl<T, B: BlockDim> BlockGrid<T, B> {
     }
 
     #[inline]
-    pub fn each_iter_mut(&mut self) -> impl Iterator<Item = (Coords, &mut T)> + ExactSizeIterator {
-        let col_blocks = self.col_blocks();
-        self.buf
-            .iter_mut()
-            .enumerate()
-            .map(move |(ind, x)| (Self::mem_index_to_coords(ind, col_blocks), x))
+    pub fn each_iter_mut(&mut self) -> EachIterMut<T, B> {
+        EachIterMut::new(self)
     }
 
     #[inline]
@@ -186,15 +182,6 @@ impl<T, B: BlockDim> BlockGrid<T, B> {
 
     fn calc_offset(&self, (row, col): Coords) -> Coords {
         (row & B::MASK, col & B::MASK)
-    }
-
-    // Have to take `col_blocks` so `self` isn't aliased
-    fn mem_index_to_coords(ind: usize, col_blocks: usize) -> Coords {
-        let block = ind / B::AREA;
-        let intra_block = ind % B::AREA;
-        let row = B::WIDTH * (block / col_blocks) + (intra_block / B::WIDTH);
-        let col = B::WIDTH * (block % col_blocks) + (intra_block % B::WIDTH);
-        (row, col)
     }
 }
 

--- a/src/iters.rs
+++ b/src/iters.rs
@@ -1,7 +1,7 @@
 use core::iter::FusedIterator;
 use core::marker::PhantomData;
 use core::ptr::NonNull;
-use core::slice::{ChunksExact, ChunksExactMut};
+use core::slice::{ChunksExact, ChunksExactMut, Iter};
 
 use crate::{Block, BlockDim, BlockGrid, BlockMut, Coords};
 
@@ -14,6 +14,14 @@ pub trait CoordsIterator: Iterator {
     {
         WithCoordsIter { iter: self }
     }
+}
+
+pub struct EachIter<'a, T, B: BlockDim> {
+    row: usize,
+    col: usize,
+    cols: usize,
+    iter: Iter<'a, T>,
+    _phantom: PhantomData<B>,
 }
 
 pub struct BlockIter<'a, T, B: BlockDim> {
@@ -47,6 +55,47 @@ pub struct RowMajorIterMut<'a, T, B: BlockDim> {
 
 pub struct WithCoordsIter<I> {
     iter: I,
+}
+
+impl<'a, T, B: BlockDim> EachIter<'a, T, B> {
+    pub(crate) fn new(grid: &'a BlockGrid<T, B>) -> Self {
+        Self {
+            row: 0,
+            col: 0,
+            cols: grid.cols(),
+            iter: grid.raw().iter(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, T, B: BlockDim> CoordsIterator for EachIter<'a, T, B> {
+    #[inline]
+    fn current_coords(&self) -> Coords {
+        (self.row, self.col)
+    }
+}
+
+impl<'a, T, B: BlockDim> Iterator for EachIter<'a, T, B> {
+    type Item = &'a T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.col += 1;
+        if self.col % B::WIDTH == 0 {
+            self.row += 1;
+            if self.row % B::WIDTH == 0 {
+                if self.col == self.cols {
+                    self.col = 0;
+                } else {
+                    self.row -= B::WIDTH;
+                }
+            } else {
+                self.col -= B::WIDTH;
+            }
+        }
+        self.iter.next()
+    }
 }
 
 // TODO: See if I can use the anonymous lifetime `'_` everywhere here

--- a/src/iters.rs
+++ b/src/iters.rs
@@ -1,7 +1,7 @@
 use core::iter::FusedIterator;
 use core::marker::PhantomData;
 use core::ptr::NonNull;
-use core::slice::{ChunksExact, ChunksExactMut, Iter};
+use core::slice::{ChunksExact, ChunksExactMut, Iter, IterMut};
 
 use crate::{Block, BlockDim, BlockGrid, BlockMut, Coords};
 
@@ -21,6 +21,14 @@ pub struct EachIter<'a, T, B: BlockDim> {
     col: usize,
     cols: usize,
     iter: Iter<'a, T>,
+    _phantom: PhantomData<B>,
+}
+
+pub struct EachIterMut<'a, T, B: BlockDim> {
+    row: usize,
+    col: usize,
+    cols: usize,
+    iter: IterMut<'a, T>,
     _phantom: PhantomData<B>,
 }
 
@@ -78,6 +86,47 @@ impl<'a, T, B: BlockDim> CoordsIterator for EachIter<'a, T, B> {
 
 impl<'a, T, B: BlockDim> Iterator for EachIter<'a, T, B> {
     type Item = &'a T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.col += 1;
+        if self.col % B::WIDTH == 0 {
+            self.row += 1;
+            if self.row % B::WIDTH == 0 {
+                if self.col == self.cols {
+                    self.col = 0;
+                } else {
+                    self.row -= B::WIDTH;
+                }
+            } else {
+                self.col -= B::WIDTH;
+            }
+        }
+        self.iter.next()
+    }
+}
+
+impl<'a, T, B: BlockDim> EachIterMut<'a, T, B> {
+    pub(crate) fn new(grid: &'a mut BlockGrid<T, B>) -> Self {
+        Self {
+            row: 0,
+            col: 0,
+            cols: grid.cols(),
+            iter: grid.raw_mut().iter_mut(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, T, B: BlockDim> CoordsIterator for EachIterMut<'a, T, B> {
+    #[inline]
+    fn current_coords(&self) -> Coords {
+        (self.row, self.col)
+    }
+}
+
+impl<'a, T, B: BlockDim> Iterator for EachIterMut<'a, T, B> {
+    type Item = &'a mut T;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -143,7 +143,7 @@ fn gen_each_iter_mut<B: BlockDim>() {
     assert_eq!(grid.each_iter_mut().count(), grid.size());
     let (row_blocks, col_blocks) = (grid.row_blocks(), grid.col_blocks());
     // Mutate while iterating
-    let mut it = grid.each_iter_mut();
+    let mut it = grid.each_iter_mut().coords();
     for bi in 0..row_blocks {
         for bj in 0..col_blocks {
             for si in 0..B::WIDTH {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,7 +10,7 @@ fn gen_from_raw_vec<B: BlockDim>() {
     let grid = BG::<_, B>::from_raw_vec(rows, cols, data.clone()).unwrap();
     assert_eq!((grid.rows(), grid.cols()), (rows, cols));
     assert_eq!(grid.size(), data.len());
-    for ((_, &x), &y) in grid.each_iter().zip(data.iter()) {
+    for (&x, &y) in grid.each_iter().zip(data.iter()) {
         assert_eq!(x, y);
     }
 }
@@ -20,7 +20,7 @@ fn gen_filled<B: BlockDim>() {
     let grid = BG::<_, B>::filled(rows, cols, 7).unwrap();
     assert_eq!((grid.rows(), grid.cols()), (rows, cols));
     assert_eq!(grid.size(), rows * cols);
-    for (_, &x) in grid.each_iter() {
+    for &x in grid.each_iter() {
         assert_eq!(x, 7);
     }
 }
@@ -121,7 +121,7 @@ fn gen_each_iter<B: BlockDim>() {
     let grid = BG::<_, B>::from_raw_vec(rows, cols, data).unwrap();
     assert_eq!(grid.each_iter().count(), grid.size());
 
-    let mut it = grid.each_iter();
+    let mut it = grid.each_iter().coords();
     for bi in 0..grid.row_blocks() {
         for bj in 0..grid.col_blocks() {
             for si in 0..B::WIDTH {

--- a/tb-suite/benches/unit.rs
+++ b/tb-suite/benches/unit.rs
@@ -88,9 +88,10 @@ fn iterators(c: &mut Criterion) {
     let grid = BlockGrid::<_, B>::from_raw_vec(ROWS, COLS, data).unwrap();
 
     let mut g = c.benchmark_group("Iterators");
+    // FIXME: Change names of the next two
     g.bench_function("each_iter_no_coords", |b| {
         b.iter(|| {
-            for (_, x) in grid.each_iter() {
+            for x in grid.each_iter() {
                 black_box(x);
             }
         })
@@ -98,7 +99,7 @@ fn iterators(c: &mut Criterion) {
 
     g.bench_function("each_iter", |b| {
         b.iter(|| {
-            for (c, x) in grid.each_iter() {
+            for (c, x) in grid.each_iter().coords() {
                 black_box((c, x));
             }
         })

--- a/tb-suite/benches/unit.rs
+++ b/tb-suite/benches/unit.rs
@@ -88,8 +88,7 @@ fn iterators(c: &mut Criterion) {
     let grid = BlockGrid::<_, B>::from_raw_vec(ROWS, COLS, data).unwrap();
 
     let mut g = c.benchmark_group("Iterators");
-    // FIXME: Change names of the next two
-    g.bench_function("each_iter_no_coords", |b| {
+    g.bench_function("each_iter", |b| {
         b.iter(|| {
             for x in grid.each_iter() {
                 black_box(x);
@@ -97,7 +96,7 @@ fn iterators(c: &mut Criterion) {
         })
     });
 
-    g.bench_function("each_iter", |b| {
+    g.bench_function("each_iter_coords", |b| {
         b.iter(|| {
             for (c, x) in grid.each_iter().coords() {
                 black_box((c, x));

--- a/tb-suite/src/blur.rs
+++ b/tb-suite/src/blur.rs
@@ -4,7 +4,7 @@ extern crate block_grid;
 use std::ops::{Index, IndexMut};
 
 use array2d::Array2D;
-use block_grid::{BlockDim, BlockGrid};
+use block_grid::{BlockDim, BlockGrid, CoordsIterator};
 
 /// New pixel is average of 3x3 kernel
 fn get_new_pix<G>(img: &G, (i, j): (usize, usize)) -> u8
@@ -78,7 +78,7 @@ pub fn blur_blockgrid<B: BlockDim>(img: &BlockGrid<u8, B>, out: &mut BlockGrid<u
     debug_assert!(rows >= 3 && cols >= 3);
 
     // Iterate over each pixel
-    for ((i, j), &x) in img.each_iter() {
+    for ((i, j), &x) in img.each_iter().coords() {
         // Copy perimeter
         if i == 0 || j == 0 || i == rows - 1 || j == cols - 1 {
             // SAFETY: Generated coordinates _should_ be valid


### PR DESCRIPTION
Replace `each_iter{mut}` to use `EachIter{Mut}`. Should be faster than naively calculating coordinates in reverse.

Closes #25.