### PR TITLE
Remove BlockWidth and use of mask and shift

### DIFF
--- a/src/block_grid.rs
+++ b/src/block_grid.rs
@@ -61,12 +61,12 @@ impl<T, B: BlockDim> BlockGrid<T, B> {
 
     #[inline]
     pub fn row_blocks(&self) -> usize {
-        self.rows >> B::SHIFT
+        self.rows / B::WIDTH
     }
 
     #[inline]
     pub fn col_blocks(&self) -> usize {
-        self.cols >> B::SHIFT
+        self.cols / B::WIDTH
     }
 
     #[inline]
@@ -177,11 +177,11 @@ impl<T, B: BlockDim> BlockGrid<T, B> {
     }
 
     fn calc_block(&self, (row, col): Coords) -> Coords {
-        (row >> B::SHIFT, col >> B::SHIFT)
+        (row / B::WIDTH, col / B::WIDTH)
     }
 
     fn calc_offset(&self, (row, col): Coords) -> Coords {
-        (row & B::MASK, col & B::MASK)
+        (row % B::WIDTH, col % B::WIDTH)
     }
 }
 

--- a/src/block_width.rs
+++ b/src/block_width.rs
@@ -7,13 +7,7 @@ pub trait BlockDim: Clone {
 }
 
 macro_rules! make_block_width [
-    ($($name: ident, $shift: literal);* $(;)*) => {
-
-        #[allow(non_snake_case)]
-        pub mod BlockWidth {
-            pub use super::{$($name,)*};
-        }
-
+    ($($name: ident, $shift: literal);*) => {
         $(
             #[derive(Clone, Copy, Debug)]
             pub struct $name;
@@ -34,5 +28,5 @@ make_block_width![
     U64,  6;
     U128, 7;
     U256, 8;
-    U512, 9;
+    U512, 9
 ];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod iters;
 mod tests;
 
 pub use crate::block_grid::{Block, BlockGrid, BlockMut};
-pub use crate::block_width::{BlockDim, BlockWidth};
+pub use crate::block_width::*;
 pub use crate::iters::CoordsIterator;
 
 pub type Coords = (usize, usize);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
 use std::vec::Vec;
 
-use crate::{BlockWidth::*, *};
+use crate::*;
 
 type BG<T, B> = BlockGrid<T, B>;
 

--- a/tb-suite/benches/blur.rs
+++ b/tb-suite/benches/blur.rs
@@ -5,11 +5,11 @@ extern crate fastrand;
 extern crate tb_suite;
 
 use array2d::Array2D;
-use block_grid::{BlockGrid, BlockWidth};
+use block_grid::{BlockGrid, U8};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use tb_suite::blur::*;
 
-type B = BlockWidth::U8;
+type B = U8;
 
 const ROWS: usize = 256;
 const COLS: usize = 128;

--- a/tb-suite/benches/unit.rs
+++ b/tb-suite/benches/unit.rs
@@ -5,7 +5,7 @@ use block_grid::*;
 use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
 
 type T = u8;
-type B = BlockWidth::U8;
+type B = U8;
 
 const ROWS: usize = 128;
 const COLS: usize = 256;

--- a/tb-suite/tests/blur.rs
+++ b/tb-suite/tests/blur.rs
@@ -4,7 +4,7 @@ extern crate fastrand;
 extern crate tb_suite;
 
 use array2d::Array2D;
-use block_grid::{BlockDim, BlockGrid, BlockWidth::*};
+use block_grid::*;
 use tb_suite::blur::*;
 
 fn gen_test_index<B: BlockDim>(rows: usize, cols: usize) {


### PR DESCRIPTION
Remove `BlockWidth` "fake enum" namespace. Also remove explicit usage of associated consts `MASK` and `SHIFT`.

Closes #36.