### PR TITLE
Add Serde support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 ## Unreleased
 
 - Cache `col_blocks` value in struct ([#66])
+- Add optional [Serde][serde] framework support ([#67])
 
 [#66]: https://github.com/gunvirranu/block-grid/pull/66
+[serde]: https://crates.io/crates/serde
+[#67]: https://github.com/gunvirranu/block-grid/pull/67
 
 ## 0.1.1 - 2021-02-01
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,12 @@ categories = ["data-structures", "no-std", "memory-management"]
 keywords = ["array", "grid", "2d", "matrix"]
 exclude = ["/.github/"]
 
+[dependencies.serde]
+version = "1.0"
+optional = true
+default-features = false
+features = ["derive", "alloc"]
+
 [lib]
 bench = false
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - Block level access with `Block` and `BlockMut`
 - Constructors from row-major and column-major order arrays
 - Iterators for in-memory and row-major order, and by block
-- `no_std` support
+- `no_std` and [`serde`][serde] support
 
 ## Example
 
@@ -91,6 +91,7 @@ See [`CHANGELOG.md`](CHANGELOG.md).
 If your access patterns suit a typical row-major memory representation, check out [`array2d`][array2d], [`imgref`][imgref], [`grid`][grid], or [`toodee`][toodee]. The last two support dynamic resizing. For matrices and linear algebra, there's also [`nalgebra`][nalgebra].
 
 <!-- Links -->
+[serde]: https://crates.io/crates/serde "serde"
 [array2d]: https://crates.io/crates/array2d "array2d"
 [imgref]: https://crates.io/crates/imgref "imgref"
 [grid]: https://crates.io/crates/grid "grid"

--- a/src/block_grid.rs
+++ b/src/block_grid.rs
@@ -566,8 +566,10 @@ mod serde_hack {
     use core::convert::{From, TryFrom};
     use core::fmt;
 
-    // FIXME: Document
-    #[allow(missing_docs)]
+    /// Error if invalid dimensions are passed in or deserialized.
+    ///
+    /// Currently, only used for `serde` deserialization, but in the future, this should be used
+    /// for the [`BlockGrid<T, B>`] constructors as well.
     #[derive(Debug)]
     pub(super) struct InvalidSizeError;
 
@@ -577,6 +579,9 @@ mod serde_hack {
         }
     }
 
+    /// A "trick" to avoid writing (de)serialization code with validation.
+    ///
+    /// See PR for details.
     #[derive(Deserialize, Serialize)]
     pub(super) struct ShadowBlockGrid<T> {
         rows: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,20 @@
 //! count, then there's always [`Iterator::enumerate`].
 //!
 //! [coords]: CoordsIterator::coords
+//!
+//! # Optional Features
+//!
+//! ## Serde
+//!
+//! To use the [`serde`][serde] framework, enable the optional `serde` [feature] in your
+//! `Cargo.toml`. There is an important sublety to its usage. Because the block size is generic
+//! and compile-time, you have to know `B` when deserializing. You *could* write it decide based
+//! on the input data, but I think it would lead to a bunch of extra code-gen, so I've left it
+//! out. It does, however, verify that `B` is the same value as the one originally used to
+//! serialize. If you always know the `B` value, then this shouldn't matter at all.
+//!
+//! [serde]: https://crates.io/crates/serde
+//! [feature]: https://doc.rust-lang.org/cargo/reference/features.html
 
 #![warn(missing_docs)]
 #![warn(missing_debug_implementations)]

--- a/tb-suite/Cargo.toml
+++ b/tb-suite/Cargo.toml
@@ -7,12 +7,14 @@ edition = "2018"
 publish = false
 
 [dependencies]
-block-grid = { path = ".." }
+block-grid = { path = "..", features = ["serde"] }
 array2d = "0.2.1"
 
 [dev-dependencies]
 criterion = "0.3.3"
 fastrand = "1.3.3"
+serde = "1.0"
+serde_json = "1.0"
 
 [lib]
 bench = false

--- a/tb-suite/tests/serde.rs
+++ b/tb-suite/tests/serde.rs
@@ -1,0 +1,73 @@
+extern crate block_grid;
+extern crate serde;
+extern crate serde_json;
+
+use std::iter::repeat_with;
+
+use block_grid::*;
+use serde::{Deserialize, Serialize};
+
+#[allow(clippy::upper_case_acronyms)]
+type BG<T, B> = BlockGrid<T, B>;
+
+#[test]
+fn test_serdes_u8() {
+    let bg = BG::<u8, U2>::filled(4, 8, 7).unwrap();
+    let s = serde_json::to_string(&bg).unwrap();
+    let ds = serde_json::from_str::<BG<_, U2>>(&s).unwrap();
+    assert_eq!(ds, bg);
+    assert!(serde_json::from_str::<BG<u8, U4>>(&s).is_err());
+
+    let bg = BG::<u8, U32>::new(128, 32).unwrap();
+    let s = serde_json::to_string(&bg).unwrap();
+    let ds = serde_json::from_str::<BG<u8, U32>>(&s).unwrap();
+    assert_eq!(ds, bg);
+    assert!(serde_json::from_str::<BG<u8, U16>>(&s).is_err());
+}
+
+#[test]
+fn test_serdes_i64() {
+    let data: Vec<_> = repeat_with(|| fastrand::i64(..)).take(8 * 8).collect();
+    let bg = BG::<_, U8>::from_raw_vec(8, 8, data).unwrap();
+    let s = serde_json::to_string(&bg).unwrap();
+    let ds = serde_json::from_str::<BG<i64, U8>>(&s).unwrap();
+    assert_eq!(ds, bg);
+    assert!(serde_json::from_str::<BG<i64, U2>>(&s).is_err());
+    assert!(serde_json::from_str::<BG<u64, U8>>(&s).is_err());
+    assert!(serde_json::from_str::<BG<u16, U8>>(&s).is_err());
+}
+
+#[test]
+fn test_serdes_f32() {
+    let data: Vec<_> = repeat_with(fastrand::f32).take(4 * 4).collect();
+    let bg = BG::<_, U4>::from_raw_vec(4, 4, data).unwrap();
+    let s = serde_json::to_string(&bg).unwrap();
+    let ds = serde_json::from_str::<BG<f32, U4>>(&s).unwrap();
+    assert_eq!(ds, bg);
+    assert!(serde_json::from_str::<BG<f32, U2>>(&s).is_err());
+    assert!(serde_json::from_str::<BG<i64, U4>>(&s).is_err());
+}
+
+#[test]
+fn test_serdes_rgb() {
+    #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+    struct Rgb {
+        pub r: u8,
+        pub g: u8,
+        pub b: u8,
+    }
+    let bg = {
+        let mut data = Vec::with_capacity(2 * 2);
+        for _ in 0..(2 * 2) {
+            data.push(Rgb {
+                r: fastrand::u8(..),
+                g: fastrand::u8(..),
+                b: fastrand::u8(..),
+            });
+        }
+        BG::<_, U2>::from_raw_vec(2, 2, data).unwrap()
+    };
+    let s = serde_json::to_string(&bg).unwrap();
+    let ds = serde_json::from_str::<BG<Rgb, U2>>(&s).unwrap();
+    assert_eq!(bg, ds);
+}


### PR DESCRIPTION
Add optional [`serde`](https://crates.io/crates/serde) support. Some notes:

- Required bounds on `T: Clone + Serialize + Deserialize`
  - `Clone` required cause of an implementation detail, but I don't forsee this being an issue.
- You have to know `B` when deserializing
  - I *could* write it to use the `B` from data, but since `BlockGrid<_, B>` is solely compile-time, it's extra code-gen I think (for each `U*`). Imo, not needed atm.
  - If you know the `B` value, then this doesn't matter at all.
- Weird implementation detail: https://github.com/serde-rs/serde/issues/642#issuecomment-683276351
  - Three options: One, I just (de)serialize `BlockGrid<T, B>`, but this can lead to unsoundness if input data is invalid. Two, I write a custom `(De)Serialize` impl, but I don't really wanna do that. The above seems like the "nicest" way to validate the input without extra work.

Closes #52.